### PR TITLE
use global to get a window handle

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,3 +1,4 @@
+var window = require('global');
 var httpism = require('./httpism');
 var utils = require('./middlewareUtils');
 var qs = require('qs');
@@ -85,7 +86,7 @@ function responseUrl(xhr, requestUrl) {
 }
 
 function send(request) {
-  var xhr = new XMLHttpRequest();
+  var xhr = new window.XMLHttpRequest();
   var reject;
 
   var promise = new Promise(function (fulfil, _reject) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "debug": "2.2.0",
+    "global": "4.3.0",
     "https-proxy-agent": "1.0.0",
     "qs": "^0.6.6",
     "tough-cookie": "2.2.0",


### PR DESCRIPTION
this is useful when you want to use `require('httpism/browser')` in node, it then allows you to provide a mock XMLHttpRequest object by:

`require('global').XMLHttpRequest = function(){}`

I specifically need to be able to do this because I am trying to test plastiq browser applications in node