### PR TITLE
Don't encode undefined values in querystrings

### DIFF
--- a/querystring-lite.js
+++ b/querystring-lite.js
@@ -13,8 +13,13 @@ module.exports = {
   },
 
   stringify: function (params) {
-    return Object.keys(params).map(function (key) {
-      return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
-    }).join('&');
+    return Object.keys(params)
+      .filter(function (key) {
+        return typeof(params[key]) !== 'undefined';
+      })
+      .map(function (key) {
+        return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+      })
+      .join('&');
   }
 };

--- a/test/querystringSpec.js
+++ b/test/querystringSpec.js
@@ -1,0 +1,12 @@
+var qs = require('../querystring-lite');
+var chai = require("chai");
+var expect = chai.expect;
+
+describe('querystring', function() {
+  describe('.stringify({})', function() {
+    it('ignores undefined values', function() {
+      var stringified = qs.stringify({ foo: 123, bar: undefined });
+      expect(stringified).to.equal("foo=123")
+    })
+  })
+})


### PR DESCRIPTION
I think this makes the API a bit friendlier. Do you agree?

Not sure about null values, but my instinct is that's a bit different...