### PR TITLE
Use browser middleware on electron

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,17 +1,8 @@
 var httpism = require('./httpism');
-var middleware = require('./browserMiddleware');
-var utils = require('./middlewareUtils');
+var browserMiddlewareStack = require('./browserMiddlewareStack');
 
 module.exports = httpism(
   undefined,
   {},
-  [
-    middleware.jsonp,
-    utils.exception,
-    middleware.form,
-    middleware.json,
-    middleware.text,
-    utils.querystring,
-    middleware.send
-  ]
+  browserMiddlewareStack
 );

--- a/browserMiddlewareStack.js
+++ b/browserMiddlewareStack.js
@@ -1,0 +1,12 @@
+var utils = require('./middlewareUtils');
+var middleware = require('./browserMiddleware');
+
+module.exports = [
+  middleware.jsonp,
+  utils.exception,
+  middleware.form,
+  middleware.json,
+  middleware.text,
+  utils.querystring,
+  middleware.send
+];

--- a/index.js
+++ b/index.js
@@ -1,23 +1,28 @@
 var middleware = require('./middleware');
 var httpism = require('./httpism');
+var browserMiddlewareStack = require('./browserMiddlewareStack');
 
-module.exports = httpism(
-  undefined,
-  {},
-  [
-    middleware.log,
-    middleware.exception,
-    middleware.text,
-    middleware.form,
-    middleware.json,
-    middleware.querystring,
-    middleware.basicAuth,
-    middleware.redirect,
-    middleware.cookies,
-    middleware.streamContentType,
-    middleware.debugLog,
-    middleware.http
-  ]
+var isElectron = typeof window !== 'undefined';
+
+module.exports = httpism(undefined, {},
+  isElectron
+  ?
+    browserMiddlewareStack
+  :
+    [
+      middleware.log,
+      middleware.exception,
+      middleware.text,
+      middleware.form,
+      middleware.json,
+      middleware.querystring,
+      middleware.basicAuth,
+      middleware.redirect,
+      middleware.cookies,
+      middleware.streamContentType,
+      middleware.debugLog,
+      middleware.http
+    ]
 );
 
 module.exports.raw = httpism(undefined, {}, [middleware.http]);


### PR DESCRIPTION
So when httpism is used in electron renderer process it is using xhr rather than node's http.

Because that is probably what you want in an SPA. And then mock-xhr-router
can mock it.