### PR TITLE
logging: report both time to get headers and body

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -223,12 +223,15 @@ middleware('debugLog', function(request, next) {
   if (debug.enabled) {
     var startTime = Date.now();
     return next().then(function (response) {
-      var time = Date.now() - startTime;
-      debug(request.method.toUpperCase() + ' ' + obfuscateUrlPassword(request.url) + ' => ' + response.statusCode + ' (' + time + 'ms)');
+      var headerTime = Date.now() - startTime;
+      response.body.on('end', function () {
+        var bodyTime = Date.now() - startTime;
+        debug(request.method.toUpperCase() + ' ' + obfuscateUrlPassword(request.url) + ' => ' + response.statusCode + ' (' + headerTime + 'ms, ' + bodyTime + 'ms)');
+      })
       return response;
     }, function (error) {
-      var time = Date.now() - startTime;
-      debug(request.method.toUpperCase() + ' ' + obfuscateUrlPassword(request.url) + ' => ' + error.message + ' (' + time + 'ms)');
+      var headerTime = Date.now() - startTime;
+      debug(request.method.toUpperCase() + ' ' + obfuscateUrlPassword(request.url) + ' => ' + error.message + ' (' + headerTime + 'ms)');
       throw error;
     });
   } else {


### PR DESCRIPTION
Looks a bit like this:

```
  httpism GET http://localhost:12345/ => 200 (109ms, 520ms) +546ms
```