### PR TITLE
better support for proxy environment variables

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -12,6 +12,7 @@ var debugRequest = createDebug("httpism:request");
 var HttpsProxyAgent = require('https-proxy-agent');
 var obfuscateUrlPassword = require('./obfuscateUrlPassword');
 var mimeTypes = require('mime-types');
+var proxyForUrl = require('proxy-from-env').getProxyForUrl
 
 function middleware(name, fn) {
   exports[name] = fn;
@@ -126,7 +127,7 @@ function proxyUrl(request, proxy) {
 }
 
 function parseUrl(request) {
-  var proxy = process.env.http_proxy || process.env.HTTP_PROXY || request.options.proxy;
+  var proxy = proxyForUrl(request.url) || request.options.proxy
 
   if (proxy) {
     return proxyUrl(request, proxy);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "global": "4.3.1",
     "https-proxy-agent": "1.0.0",
     "mime-types": "2.1.14",
+    "proxy-from-env": "1.0.0",
     "random-string": "0.1.2",
     "tough-cookie": "2.3.2",
     "underscore": "1.8.3"

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,17 @@ DEBUG=httpism* node app.js
 
 More information in debug's README.
 
+## Proxy Environment Variables
+
+Httpism obeys the following environments variables:
+
+    * `http_proxy` `HTTP_PROXY` - for HTTP requests
+    * `https_proxy` `HTTPS_PROXY` - for HTTPS requests
+    * `all_proxy` `ALL_PROXY` - for HTTP or HTTPS requests
+    * `no_proxy` `NO_PROXY` - an comma separated list of hostnames (and optional ports) to not proxy
+
+For more details please see [proxy-from-env](https://github.com/Rob--W/proxy-from-env).
+
 ## Requests
 
 ### GET, HEAD, DELETE


### PR DESCRIPTION
* `http_proxy` `HTTP_PROXY` - for HTTP requests
* `https_proxy` `HTTPS_PROXY` - for HTTPS requests
* `all_proxy` `ALL_PROXY` - for HTTP or HTTPS requests
* `no_proxy` `NO_PROXY` - an comma separated list of hostnames (and optional ports) to not proxy