### PR TITLE
params

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -11,6 +11,7 @@ module.exports = httpism(
     middleware.form,
     middleware.json,
     middleware.text,
+    utils.expandUrl,
     utils.querystring,
     middleware.send
   ]

--- a/browserMiddleware.js
+++ b/browserMiddleware.js
@@ -8,6 +8,10 @@ function middleware(name, fn) {
   fn.middleware = name;
 }
 
+middleware('exception', utils.exception);
+middleware('querystring', utils.querystring);
+middleware('expandUrl', utils.expandUrl);
+
 middleware('json', function(request, next) {
   if (request.body instanceof Object) {
     request.body = JSON.stringify(request.body);

--- a/httpism.js
+++ b/httpism.js
@@ -109,10 +109,6 @@ function lowerCaseHeaders(headers) {
   return headers;
 }
 
-function makeResponse(client, response) {
-  return utils.extend(new Httpism(client.url, client._options, client.middlewares), response);
-}
-
 function findMiddlewareIndexes(names, middlewares) {
   return names.map(function (name) {
     for(var n = 0; n < middlewares.length; n++) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = httpism(
     middleware.text,
     middleware.form,
     middleware.json,
+    middleware.expandUrl,
     middleware.querystring,
     middleware.basicAuth,
     middleware.redirect,

--- a/middleware.js
+++ b/middleware.js
@@ -20,6 +20,7 @@ function middleware(name, fn) {
 
 middleware('exception', utils.exception);
 middleware('querystring', utils.querystring);
+middleware('expandUrl', utils.expandUrl);
 
 exports.streamToString = function(s) {
   return new Promise(function(result, error) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "phantomjs-prebuilt": "2.1.14",
     "qs": "6.4.0",
     "server-destroy": "1.0.1",
+    "uglify-js": "2.8.21",
     "url-template": "2.0.8",
     "watchify": "3.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "phantomjs-prebuilt": "2.1.14",
     "qs": "6.4.0",
     "server-destroy": "1.0.1",
+    "url-template": "2.0.8",
     "watchify": "3.9.0"
   },
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,21 @@
 httpism is a node and browser HTTP client that does a few things differently:
 
 * **middleware**: customise a HTTP client for your API by sticking together middleware, for example, for content handlers or authentication schemes.
-* **hypermedia**: responses can be used to make further requests relative to the response URI, just like a browser.
 * **useful by default**: sends and receives JSON, throws exceptions on 400-500s, follows redirects. Of course, you can disable this stuff when it gets in your way, or hit raw HTTP and streams when you need to get clever.
 * **promises**: no messing about with callbacks.
 * for **browser** and **server** alike.
+
+In addition, httpism supports:
+
+* URL templates
+* Cookies
+* HTTP proxies for HTTP and HTTPS traffic, with proxy authentication
+* Basic authentication
+* JSON
+* URL encoded forms
+* streams
+* CORS
+* JSONP
 
 ## NPM: [httpism](https://www.npmjs.org/package/httpism)
 
@@ -333,6 +344,7 @@ promise.abort();
 * `redirect`: default `true`, follow redirects for 300, 301, 302, 303 and 307 status codes with `Location` response headers. Set to `false` to simply return the redirect response.
 * `headers`: default `undefined`, can be set to an object that is merged with middleware headers.
 * `basicAuth`: use Basic Authentication, pass an object `{ username: 'bob', password: "bob's secret" }`.
+* `cookies`: default `false`, use cookies.
 * `querystring`: default `undefined`, can be set to an object containing fields that are URL-encoded and merged with the querystring already on the URL, if any. This is parsed and stringified using `options.qs.parse` and `options.qs.stringify` if provided, or using a very lite internal query string parser.
 * `qs`: optional override for parsing and stringifying querystrings, you can pass node's `querystring` or `qs`. Any object that contains the methods `parse` and `stringify` can be used. If not provided, httpism will use an internal (and very small) query string parser/stringifier.
 * `form`: when `true`, treats the incoming JSON data as a form and encodes it as `application/x-www-form-urlencoded`.

--- a/readme.md
+++ b/readme.md
@@ -35,9 +35,9 @@ Compatible with browserify too!
 
 ## Browser Size
 
-* httpism.js: 13K
-* httpism.min.js: 6.8K
-* httpism.min.js.gz: 2.6K
+* httpism.js: 20K
+* httpism.min.js: 11K
+* httpism.min.js.gz: 3.9K
 
 ## GET JSON
 


### PR DESCRIPTION
### Params

Httpism will render a URL template if the `params` option is used, the params are interpolated into the URL template, any params left over will form the query string.

```js
httpism.get('http://example.com/users/:user/posts', {
  params: {
    user: 'bob',
    page: 3,
    search: 'lakes'
  }
})
```

Will become

```
GET http://example.com/users/bob/posts?page=3&search=lakes
```

A template contains two forms of parameter, varying on the way special characters are encoded for URLs.

* `:param` - uses `encodeURIComponent`, and is useful for most applications
* `:param*` - uses `encodeURI` and can be used to interpolate paths, such as `a/path/to/something` without encoding the slash characters.

Any remaining parameters will be encoded in the query string, you can override how the query string is encoded using the `qs` option.

The template interpolation itself can be overridden with the `expandUrl` option, and is used as follows:

```js
var url = expandUrl(template, params, querystring)
```

* `template` - the URL template, passed in as the `url` argument to `httpism.get`, etc.
* `params` - the object containing the parameters to be interpolated.
* `querystring` - the `qs` option, can be used to encode the query string parameters, e.g. `querystring.stringify(params)`.

For example, you could use RFC 6570 templates like this

```js
var urlTemplate = require('url-template')

function expandUrl(url, params) {
  var template = urlTemplate.parse(url)
  return template.expand(params)
}

httpism.get('http://example.com/users/{user}/posts{?page,search}', {
  params: {
    user: 'bob',
    page: 3,
    search: 'lakes'
  },
  expandUrl: expandUrl
})
```

Or indeed create a new client to use this by default:

```js
var httpism = require('httpsim').client({
  expandUrl: expandUrl
})

httpism.get('http://example.com/users/{user}/posts{?page,search}')
```
