### PR TITLE
Fix merging headers in options

### DIFF
--- a/client.js
+++ b/client.js
@@ -23,7 +23,7 @@ Httpism.prototype.request = function (method, url, body, _options) {
   if (method instanceof Object) {
     request = method
   } else {
-    var options = merge(_options, this._options)
+    var options = mergeClientOptions(_options, this._options)
     request = {
       method: method,
       url: resolveUrl(this.url, url),
@@ -138,7 +138,7 @@ Httpism.prototype.client = function (url, options, middleware) {
 
   var client = new Httpism(
     resolveUrl(this.url, args.url),
-    merge(args.options, this._options),
+    mergeClientOptions(args.options, this._options),
     this.middleware.slice()
   )
 
@@ -237,6 +237,12 @@ function parseClientArguments () {
     options: options,
     middleware: middleware
   }
+}
+
+function mergeClientOptions (x, y) {
+  var z = merge(x, y)
+  if (z && z.headers) { z.headers = merge(x && x.headers, y && y.headers) }
+  return z
 }
 
 module.exports = client

--- a/test/httpismSpec.js
+++ b/test/httpismSpec.js
@@ -363,6 +363,24 @@ describe('httpism', function () {
         })
       })
 
+      it('can make a new client that adds headers by passing them to options', function () {
+        app.get('/', function (req, res) {
+          res.send({
+            x: req.headers.x,
+            y: req.headers.y
+          })
+        })
+
+        var client = httpism.client('/', { headers: { x: '123' } }).client('/', { headers: { y: '456' } })
+
+        return client.get(baseurl).then(function (body) {
+          expect(body).to.eql({
+            x: '123',
+            y: '456'
+          })
+        })
+      })
+
       describe('cache example', function () {
         var filename = pathUtils.join(__dirname, 'cachefile.txt')
 

--- a/test/httpismSpec.js
+++ b/test/httpismSpec.js
@@ -381,6 +381,24 @@ describe('httpism', function () {
         })
       })
 
+      it('makes requests with additional headers', function () {
+        app.get('/', function (req, res) {
+          res.send({
+            x: req.headers.x,
+            y: req.headers.y
+          })
+        })
+
+        var client = httpism.client({ headers: { x: '123' } })
+
+        return client.get(baseurl, { headers: { y: '456' } }).then(function (body) {
+          expect(body).to.eql({
+            x: '123',
+            y: '456'
+          })
+        })
+      })
+
       describe('cache example', function () {
         var filename = pathUtils.join(__dirname, 'cachefile.txt')
 


### PR DESCRIPTION
Creating a client from another client that already had headers set, would not merge the headers (because merging client options is shallow).