### PR TITLE
Throw an error if a param gets an undefined value

### DIFF
--- a/expandUrl.js
+++ b/expandUrl.js
@@ -11,12 +11,18 @@ module.exports = function expandUrl (pattern, _params, _qs) {
   var pathPattern = uri.pathname
   var path = pathPattern.replace(/:([a-z_][a-z0-9_]*)\*/gi, function (_, id) {
     var param = params[id]
+    if (param === undefined) {
+      throw new Error('No value for :' + id + '*')
+    }
     delete onlyQueryParams[id]
     return encodeURI(paramToString(param))
   })
 
   path = path.replace(/:([a-z_][a-z0-9_]*)/gi, function (_, id) {
     var param = params[id]
+    if (param === undefined) {
+      throw new Error('No value for :' + id)
+    }
     delete onlyQueryParams[id]
     return encodeURIComponent(paramToString(param))
   })

--- a/readme.md
+++ b/readme.md
@@ -237,6 +237,8 @@ A template contains two forms of parameter, varying on the way special character
 
 Any remaining parameters will be encoded in the query string, you can override how the query string is encoded using the `qs` option.
 
+The template interpolation will throw an error if one of the `:param` or `:param*` parameters are given an `undefined` value. 
+
 The template interpolation itself can be overridden with the `expandUrl` option, and is used as follows:
 
 ```js

--- a/test/expandUrlSpec.js
+++ b/test/expandUrlSpec.js
@@ -15,9 +15,17 @@ describe('expandUrl', function () {
     expect(url).to.equal('https://example.com/path/one%2Ftwo/file')
   })
 
+  it('throws an error when a simple path param is missing', function () {
+    expect(function () { expandUrl('https://example.com/path/:param/file', {}) }).to.throw('No value for :param')
+  })
+
   it('replaces full path params', function () {
     var url = expandUrl('https://example.com/path/:param*/file', {param: 'one/two'})
     expect(url).to.equal('https://example.com/path/one/two/file')
+  })
+
+  it('throws an error when a full path param is missing', function () {
+    expect(function () { expandUrl('https://example.com/path/:param*/file', {}) }).to.throw('No value for :param*')
   })
 
   it('maintains hash', function () {


### PR DESCRIPTION
We may accidentally fail to pass a value to a param:

```javascript
const user = functionThatAccidentallyReturnsUndefined()
httpism.get('http://example.com/users/:user/posts', {
  params: {
    user
  }
})
```

This PR causes an error to be thrown for missing param values.