### PR TITLE
log URLs with params already interpolated

### DIFF
--- a/middleware/debugLog.js
+++ b/middleware/debugLog.js
@@ -1,8 +1,14 @@
 var middleware = require('./middleware')
 var debug = require('debug')('httpism')
 var obfuscateUrlPassword = require('../obfuscateUrlPassword')
+var createDebug = require('debug')
+var debugRequest = createDebug('httpism:request')
+var prepareForLogging = require('./prepareForLogging')
 
 module.exports = middleware('debugLog', function (request, next) {
+  if (debugRequest.enabled) {
+    debugRequest(prepareForLogging(request))
+  }
   if (debug.enabled) {
     var startTime = Date.now()
     return next().then(function (response) {

--- a/middleware/formServer.js
+++ b/middleware/formServer.js
@@ -3,7 +3,7 @@ var isStream = require('../isStream')
 var setBodyToString = require('../setBodyToString')
 var setHeaderTo = require('../setHeaderTo')
 var shouldParseAs = require('../shouldParseAs')
-var streamToString = require('../streamToString')
+var readBodyAsString = require('../readBodyAsString')
 var querystringLite = require('../querystring-lite')
 
 module.exports = middleware('form', function (request, next) {
@@ -15,9 +15,9 @@ module.exports = middleware('form', function (request, next) {
 
   return next().then(function (response) {
     if (shouldParseAs(response, 'form', request)) {
-      return streamToString(response.body).then(function (body) {
+      return readBodyAsString(response).then(function () {
         var querystring = request.options.qs || querystringLite
-        response.body = querystring.parse(body)
+        response.body = querystring.parse(response.stringBody)
         return response
       })
     } else {

--- a/middleware/jsonServer.js
+++ b/middleware/jsonServer.js
@@ -3,7 +3,7 @@ var isStream = require('../isStream')
 var setBodyToString = require('../setBodyToString')
 var setHeaderTo = require('../setHeaderTo')
 var shouldParseAs = require('../shouldParseAs')
-var streamToString = require('../streamToString')
+var readBodyAsString = require('../readBodyAsString')
 
 module.exports = middleware('json', function (request, next) {
   if (request.body instanceof Object && !isStream(request.body)) {
@@ -15,8 +15,8 @@ module.exports = middleware('json', function (request, next) {
 
   return next().then(function (response) {
     if (shouldParseAs(response, 'json', request)) {
-      return streamToString(response.body).then(function (jsonString) {
-        response.body = JSON.parse(jsonString, request.options.jsonReviver)
+      return readBodyAsString(response).then(function () {
+        response.body = JSON.parse(response.stringBody, request.options.jsonReviver)
         return response
       })
     } else {

--- a/middleware/log.js
+++ b/middleware/log.js
@@ -1,16 +1,8 @@
 var middleware = require('./middleware')
 var extend = require('../extend')
-var obfuscateUrlPassword = require('../obfuscateUrlPassword')
 var createDebug = require('debug')
-var debugRequest = createDebug('httpism:request')
 var debugResponse = createDebug('httpism:response')
-var isStream = require('../isStream')
-
-function logRequest (request) {
-  if (debugRequest.enabled) {
-    debugRequest(prepareForLogging(request))
-  }
-}
+var prepareForLogging = require('./prepareForLogging')
 
 function logResponse (response) {
   if (!response.redirectResponse) {
@@ -18,29 +10,8 @@ function logResponse (response) {
   }
 }
 
-function prepareForLogging (r) {
-  return removeUndefined({
-    method: r.method,
-    url: r.url && obfuscateUrlPassword(r.url),
-    headers: r.headers,
-    body: isStream(r.body) ? '[Stream]' : r.body,
-    statusCode: r.statusCode,
-    statusText: r.statusText
-  })
-}
-
-function removeUndefined (obj) {
-  Object.keys(obj).map(function (key) {
-    if (typeof obj[key] === 'undefined') {
-      delete obj[key]
-    }
-  })
-
-  return obj
-}
-
 module.exports = middleware('log', function (request, next) {
-  logRequest(request)
+  request.logBody = request.body
 
   var promise = next()
 
@@ -58,5 +29,4 @@ module.exports = middleware('log', function (request, next) {
   }
 })
 
-module.exports.logRequest = logRequest
 module.exports.logResponse = logResponse

--- a/middleware/log.js
+++ b/middleware/log.js
@@ -11,8 +11,6 @@ function logResponse (response) {
 }
 
 module.exports = middleware('log', function (request, next) {
-  request.logBody = request.body
-
   var promise = next()
 
   if (debugResponse.enabled) {

--- a/middleware/prepareForLogging.js
+++ b/middleware/prepareForLogging.js
@@ -1,12 +1,11 @@
 var obfuscateUrlPassword = require('../obfuscateUrlPassword')
-var isStream = require('../isStream')
 
 module.exports = function prepareForLogging (r) {
   return removeUndefined({
     method: r.method,
     url: r.url && obfuscateUrlPassword(r.url),
-    headers: obfuscateHeaders(r.headers),
-    body: isStream(r.logBody) ? '[Stream]' : r.logBody,
+    headers: r.headers && obfuscateHeaders(r.headers),
+    body: r.stringBody !== undefined ? r.stringBody : r.body ? '[Stream]' : undefined,
     statusCode: r.statusCode,
     statusText: r.statusText
   })

--- a/middleware/prepareForLogging.js
+++ b/middleware/prepareForLogging.js
@@ -1,0 +1,23 @@
+var obfuscateUrlPassword = require('../obfuscateUrlPassword')
+var isStream = require('../isStream')
+
+module.exports = function prepareForLogging (r) {
+  return removeUndefined({
+    method: r.method,
+    url: r.url && obfuscateUrlPassword(r.url),
+    headers: r.headers,
+    body: isStream(r.logBody) ? '[Stream]' : r.logBody,
+    statusCode: r.statusCode,
+    statusText: r.statusText
+  })
+}
+
+function removeUndefined (obj) {
+  Object.keys(obj).map(function (key) {
+    if (typeof obj[key] === 'undefined') {
+      delete obj[key]
+    }
+  })
+
+  return obj
+}

--- a/middleware/prepareForLogging.js
+++ b/middleware/prepareForLogging.js
@@ -5,15 +5,27 @@ module.exports = function prepareForLogging (r) {
   return removeUndefined({
     method: r.method,
     url: r.url && obfuscateUrlPassword(r.url),
-    headers: r.headers,
+    headers: obfuscateHeaders(r.headers),
     body: isStream(r.logBody) ? '[Stream]' : r.logBody,
     statusCode: r.statusCode,
     statusText: r.statusText
   })
 }
 
+function obfuscateHeaders (headers) {
+  var result = {}
+  Object.keys(headers).forEach(function (key) {
+    if (key === 'authorization') {
+      result[key] = String(headers[key]).split(' ')[0] + ' ********'
+    } else {
+      result[key] = headers[key]
+    }
+  })
+  return result
+}
+
 function removeUndefined (obj) {
-  Object.keys(obj).map(function (key) {
+  Object.keys(obj).forEach(function (key) {
     if (typeof obj[key] === 'undefined') {
       delete obj[key]
     }

--- a/middleware/textServer.js
+++ b/middleware/textServer.js
@@ -2,7 +2,7 @@ var middleware = require('./middleware')
 var setBodyToString = require('../setBodyToString')
 var setHeaderTo = require('../setHeaderTo')
 var shouldParseAs = require('../shouldParseAs')
-var streamToString = require('../streamToString')
+var readBodyAsString = require('../readBodyAsString')
 
 module.exports = middleware('text', function (request, next) {
   if (typeof request.body === 'string') {
@@ -12,8 +12,8 @@ module.exports = middleware('text', function (request, next) {
 
   return next().then(function (response) {
     if (shouldParseAs(response, 'text', request)) {
-      return streamToString(response.body).then(function (body) {
-        response.body = body
+      return readBodyAsString(response).then(function () {
+        response.body = response.stringBody
         return response
       })
     } else {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "test": "npm run test-mocha && npm run test-browser -- --single-run --browsers Electron && eslint .",
     "test-browser": "karma start",
-    "test-mocha": "mocha",
+    "test-mocha": "DEBUG=httpism* mocha",
     "size": "webpack browser.js _httpism.js && uglifyjs --compress warnings=false --mangle -- _httpism.js > _httpism.min.js && gzip < _httpism.min.js > _httpism.min.js.gz && ls -lh _httpism.*"
   },
   "repository": {

--- a/readBodyAsString.js
+++ b/readBodyAsString.js
@@ -1,0 +1,7 @@
+var streamToString = require('./streamToString')
+
+module.exports = function (r) {
+  return streamToString(r.body).then(function (string) {
+    r.stringBody = string
+  })
+}

--- a/setBodyToString.js
+++ b/setBodyToString.js
@@ -3,4 +3,5 @@ var stringToStream = require('./stringToStream')
 module.exports = function (r, s) {
   r.body = stringToStream(s)
   r.headers['content-length'] = Buffer.byteLength(s, 'utf-8')
+  r.stringBody = s
 }

--- a/setBodyToString.js
+++ b/setBodyToString.js
@@ -3,5 +3,4 @@ var stringToStream = require('./stringToStream')
 module.exports = function (r, s) {
   r.body = stringToStream(s)
   r.headers['content-length'] = Buffer.byteLength(s, 'utf-8')
-  r.stringBody = s
 }

--- a/test/httpismSpec.js
+++ b/test/httpismSpec.js
@@ -519,6 +519,7 @@ describe('httpism', function () {
             client.use(function (req, next) {
               return next({
                 url: req.url + '?param=hi',
+                method: 'get',
                 options: {},
                 headers: {}
               })


### PR DESCRIPTION
## Log the interpolated URLs

Previously we logged out the request URL with the parameter placeholders, but no values for the paramters, making logs pretty useless. This PR ensures that the request log is made after the parameters are interpolated.

```
httpism:request { method: 'post',
httpism:request   url:
httpism:request    'http://localhost:4000/:userId/:accountId',
httpism:request   headers: {},
httpism:request   body: { } } +0ms
```

## Log the encoded body

We also print out the encoded string form of the body (i.e. encoded JSON, or encoded URL form encoding)

```
  httpism:request { method: 'post',
  httpism:request   url: 'http://localhost:12345/form',
  httpism:request   headers:
  httpism:request    { 'content-length': 41,
  httpism:request      'content-type': 'application/x-www-form-urlencoded',
  httpism:request      accept: 'application/json' },
  httpism:request   body: 'name=Betty%20Boop&address=one%20%26%20two' } +22ms
```

```
  httpism:response { url: 'https://localhost:23456/',
  httpism:response   headers:
  httpism:response    { 'x-powered-by': 'Express',
  httpism:response      'content-type': 'application/json; charset=utf-8',
  httpism:response      'content-length': '15',
  httpism:response      etag: 'W/"f-Ntggd7XPHJEBOR29ZcyipEHaqMA"',
  httpism:response      date: 'Thu, 11 Apr 2019 10:11:11 GMT',
  httpism:response      connection: 'close' },
  httpism:response   body: '{"blah":"blah"}',
  httpism:response   statusCode: 200,
  httpism:response   statusText: 'OK' } +8ms
```

## Don't give away your secrets in the Authorization header

```
  httpism:request { method: 'get',
  httpism:request   url: 'http://localhost:12345/secret',
  httpism:request   headers:
  httpism:request    { accept: 'application/json', authorization: 'Basic ********' } } +3ms
 ```