### PR TITLE
log exceptions using debug module

### DIFF
--- a/middleware/exception.js
+++ b/middleware/exception.js
@@ -1,7 +1,9 @@
 var middleware = require('./middleware')
 var extend = require('../extend')
 var obfuscateUrlPassword = require('../obfuscateUrlPassword')
-var logErrors = require('debug')('httpism:errors')
+var logError = require('debug')('httpism:error')
+var prepareForLogging = require('./prepareForLogging')
+var logDetailError = require('debug')('httpism:response:error')
 
 module.exports = middleware('exception', function (request, next) {
   return next().then(function (response) {
@@ -10,8 +12,10 @@ module.exports = middleware('exception', function (request, next) {
 
     if (isException) {
       var msg = request.method.toUpperCase() + ' ' + obfuscateUrlPassword(request.url) + ' => ' + response.statusCode + ' ' + response.statusText
-      logErrors(msg, response)
-      var error = extend(new Error(msg), response)
+      logError(msg)
+      var logResponse = prepareForLogging(response)
+      logDetailError(logResponse)
+      var error = extend(new Error(msg), logResponse)
       throw error
     } else {
       return response

--- a/middleware/exception.js
+++ b/middleware/exception.js
@@ -1,6 +1,7 @@
 var middleware = require('./middleware')
 var extend = require('../extend')
 var obfuscateUrlPassword = require('../obfuscateUrlPassword')
+var logErrors = require('debug')('httpism:errors')
 
 module.exports = middleware('exception', function (request, next) {
   return next().then(function (response) {
@@ -9,6 +10,7 @@ module.exports = middleware('exception', function (request, next) {
 
     if (isException) {
       var msg = request.method.toUpperCase() + ' ' + obfuscateUrlPassword(request.url) + ' => ' + response.statusCode + ' ' + response.statusText
+      logErrors(msg, response)
       var error = extend(new Error(msg), response)
       throw error
     } else {

--- a/middleware/xhr.js
+++ b/middleware/xhr.js
@@ -73,9 +73,11 @@ module.exports = middleware('xhr', function (request) {
     xhr.open(request.method, request.url, true)
     xhr.onload = function () {
       var statusCode = xhr.status
+      var body = statusCode === 204 ? undefined : xhr.responseText
 
       var response = {
-        body: statusCode === 204 ? undefined : xhr.responseText,
+        body: body,
+        stringBody: body,
         headers: parseHeaders(xhr.getAllResponseHeaders()),
         statusCode: statusCode,
         url: responseUrl(xhr, request.url),

--- a/readme.md
+++ b/readme.md
@@ -168,8 +168,10 @@ DEBUG=httpism* node app.js
 ```
 
 * `httpism` simple request => response, i.e. `GET http://www.example.com/api => 200 (40ms)`
-* `httpism:request` the request
-* `httpism:response` the response
+* `httpism:error` only errors, shown in simple request => response, i.e. `GET http://www.example.com/api => 500 (40ms)`
+* `httpism:request` the full request including body
+* `httpism:response` the full response including body
+* `httpism:response:error` only errors, the full response including body
 
 More information in debug's README.
 

--- a/test/browser/httpismSpec.js
+++ b/test/browser/httpismSpec.js
@@ -58,7 +58,7 @@ describe('httpism', function () {
         throw new Error('expected to throw exception')
       }, function (response) {
         expect(response.message).to.eql('GET /status/404 => 404 Not Found')
-        expect(response.body.method).to.eql('GET')
+        expect(JSON.parse(response.body).method).to.eql('GET')
         expect(response.headers['content-type']).to.equal('application/json; charset=utf-8')
         expect(response.url).to.equal('/status/404')
       })

--- a/test/httpismSpec.js
+++ b/test/httpismSpec.js
@@ -783,7 +783,7 @@ describe('httpism', function () {
         }).catch(function (e) {
           expect(e.message).to.equal('GET ' + baseurl + '/400 => 400 Bad Request')
           expect(e.statusCode).to.equal(400)
-          expect(e.body.message).to.equal('oh dear')
+          expect(e.body).to.equal('{"message":"oh dear"}')
         })
       })
 
@@ -792,8 +792,9 @@ describe('httpism', function () {
           assert.fail('expected an exception to be thrown')
         }).catch(function (e) {
           expect(e.message).to.equal('GET http://user:********@localhost:' + port + '/400 => 400 Bad Request')
+          expect(e.url).to.equal('http://user:********@localhost:' + port + '/400')
           expect(e.statusCode).to.equal(400)
-          expect(e.body.message).to.equal('oh dear')
+          expect(e.body).to.equal('{"message":"oh dear"}')
         })
       })
 
@@ -814,7 +815,7 @@ describe('httpism', function () {
           }).catch(function (e) {
             expect(e.message).to.equal('GET ' + baseurl + '/400 => 400 Bad Request')
             expect(e.statusCode).to.equal(400)
-            expect(e.body.message).to.equal('oh dear')
+            expect(e.body).to.equal('{"message":"oh dear"}')
           })
         })
 


### PR DESCRIPTION
When an exception occurs log it using the debug module.
This helps get the errors into the log when running httpism inside electron-mocha.