### PR TITLE
Allow middleware to return frozen response body

### DIFF
--- a/client.js
+++ b/client.js
@@ -63,8 +63,8 @@ function responseCompatibility (response) {
     console.warn('httpism >= 3.0.0 returns the response body by default, please pass the {response: true} option if you want the whole response')
   }
 
-  if (response.body instanceof Object) {
-    if (response.body && !response.body.hasOwnProperty('body')) {
+  if (response.body instanceof Object && !Object.isFrozen(response.body)) {
+    if (!response.body.hasOwnProperty('body')) {
       Object.defineProperty(response.body, 'body', {
         get: function () {
           responseWarning()
@@ -73,7 +73,7 @@ function responseCompatibility (response) {
       })
     }
 
-    if (response.body && !response.body.hasOwnProperty('url')) {
+    if (!response.body.hasOwnProperty('url')) {
       Object.defineProperty(response.body, 'url', {
         get: function () {
           responseWarning()
@@ -82,7 +82,7 @@ function responseCompatibility (response) {
       })
     }
 
-    if (response.body && !response.body.hasOwnProperty('statusCode')) {
+    if (!response.body.hasOwnProperty('statusCode')) {
       Object.defineProperty(response.body, 'statusCode', {
         get: function () {
           responseWarning()
@@ -91,7 +91,7 @@ function responseCompatibility (response) {
       })
     }
 
-    if (response.body && !response.body.hasOwnProperty('headers')) {
+    if (!response.body.hasOwnProperty('headers')) {
       Object.defineProperty(response.body, 'headers', {
         get: function () {
           responseWarning()

--- a/test/httpismSpec.js
+++ b/test/httpismSpec.js
@@ -543,6 +543,20 @@ describe('httpism', function () {
               expect(response).to.eql('body')
             })
           })
+
+          it('can do its own parsing and respond with a frozen body', function () {
+            client.use(function (req, next) {
+              return next().then(function (response) {
+                var body = { ice: 'cold' }
+                Object.freeze(body)
+                return { body: body }
+              })
+            })
+
+            return client.get('/', { responseBody: 'text' }).then(function (response) {
+              expect(response.ice).to.eql('cold')
+            })
+          })
         })
 
         describe('inserting middleware', function () {


### PR DESCRIPTION
When a middleware responds with a frozen response body, `httpism` fails to mutate the response to set up the v3 deprecation warnings.

This changes the deprecation to only apply when `Object.isFrozen(response.body)` returns false.