### PR TITLE
Create errors from original response, not log-prepared response

### DIFF
--- a/middleware/exception.js
+++ b/middleware/exception.js
@@ -11,11 +11,13 @@ module.exports = middleware('exception', function (request, next) {
     var isException = exceptions === false ? false : typeof exceptions === 'function' ? exceptions(response) : response.statusCode >= 400
 
     if (isException) {
-      var msg = request.method.toUpperCase() + ' ' + obfuscateUrlPassword(request.url) + ' => ' + response.statusCode + ' ' + response.statusText
+      var obfuscatedUrl = obfuscateUrlPassword(request.url)
+      var msg = request.method.toUpperCase() + ' ' + obfuscatedUrl + ' => ' + response.statusCode + ' ' + response.statusText
       logError(msg)
       var logResponse = prepareForLogging(response)
       logDetailError(logResponse)
-      var error = extend(new Error(msg), logResponse)
+      var error = extend(new Error(msg), response)
+      error.url = obfuscatedUrl
       throw error
     } else {
       return response

--- a/test/browser/httpismSpec.js
+++ b/test/browser/httpismSpec.js
@@ -58,7 +58,7 @@ describe('httpism', function () {
         throw new Error('expected to throw exception')
       }, function (response) {
         expect(response.message).to.eql('GET /status/404 => 404 Not Found')
-        expect(JSON.parse(response.body).method).to.eql('GET')
+        expect(response.body.method).to.eql('GET')
         expect(response.headers['content-type']).to.equal('application/json; charset=utf-8')
         expect(response.url).to.equal('/status/404')
       })

--- a/test/httpismSpec.js
+++ b/test/httpismSpec.js
@@ -797,7 +797,7 @@ describe('httpism', function () {
         }).catch(function (e) {
           expect(e.message).to.equal('GET ' + baseurl + '/400 => 400 Bad Request')
           expect(e.statusCode).to.equal(400)
-          expect(e.body).to.equal('{"message":"oh dear"}')
+          expect(e.body.message).to.equal('oh dear')
         })
       })
 
@@ -808,7 +808,7 @@ describe('httpism', function () {
           expect(e.message).to.equal('GET http://user:********@localhost:' + port + '/400 => 400 Bad Request')
           expect(e.url).to.equal('http://user:********@localhost:' + port + '/400')
           expect(e.statusCode).to.equal(400)
-          expect(e.body).to.equal('{"message":"oh dear"}')
+          expect(e.body.message).to.equal('oh dear')
         })
       })
 
@@ -829,7 +829,7 @@ describe('httpism', function () {
           }).catch(function (e) {
             expect(e.message).to.equal('GET ' + baseurl + '/400 => 400 Bad Request')
             expect(e.statusCode).to.equal(400)
-            expect(e.body).to.equal('{"message":"oh dear"}')
+            expect(e.body.message).to.equal('oh dear')
           })
         })
 


### PR DESCRIPTION
When we introduced a [change](https://github.com/featurist/httpism/pull/45/files#diff-67f819bf01d08a3bea89368e891a0ba4R18) to log exceptions using the debug module, we inadvertently changed error objects so they contained the string representation of response body instead of the parsed response body like they used to.

Since the original response body was discarded, that meant clients needed to parse the response body _again_, which is not ideal because a) they need to know the response type and interpret the request options to know _how_ to parse the response and b) performance.

This restores the previous behaviour, i.e. errors have `body` set to the parsed body and not the string body.