### PR TITLE
don't mutate headers

### DIFF
--- a/deepExtend.js
+++ b/deepExtend.js
@@ -15,6 +15,8 @@ module.exports = function deepExtend (x, y) {
       deepExtend(r, xValue)
       deepExtend(r, yValue)
       x[key] = r
+    } else if (isObject(yValue)) {
+      x[key] = deepExtend({}, yValue)
     } else {
       x[key] = yValue
     }

--- a/test/deepExtendSpec.js
+++ b/test/deepExtendSpec.js
@@ -62,4 +62,34 @@ describe('deepExtend', function () {
       }
     })
   })
+
+  it('copied fields are cloned', function () {
+    var left = {
+    }
+
+    var right = {
+      nested: {
+        common: 'right',
+        override: 'right'
+      }
+    }
+
+    deepExtend(left, right)
+
+    expect(left).to.eql({
+      nested: {
+        common: 'right',
+        override: 'right'
+      }
+    })
+
+    left.nested.common = 'modified'
+
+    expect(right).to.eql({
+      nested: {
+        common: 'right',
+        override: 'right'
+      }
+    })
+  })
 })

--- a/test/httpismSpec.js
+++ b/test/httpismSpec.js
@@ -251,6 +251,26 @@ describe('httpism', function () {
           expect(body['x-header']).to.equal('haha')
         })
       })
+
+      it('headers are not mutated during the request', function () {
+        app.post('/', function (req, res) {
+          res.send({
+            'x-header': req.headers['x-header']
+          })
+        })
+
+        var headers = {
+          'x-header': 'haha'
+        }
+
+        return httpism.post(baseurl, { body: 'my body' }, {
+          headers: headers
+        }).then(function (body) {
+          expect(headers).to.eql({
+            'x-header': 'haha'
+          })
+        })
+      })
     })
 
     describe('text', function () {


### PR DESCRIPTION
Bug: if you pass headers in they can be modified during a POST request (adding things like content-type and content-length). This is normally bad if you plan to use the headers object for another request.

Fix: make sure we clone the headers when they're specified.